### PR TITLE
Add wildcard to remotePatterns host for images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,7 @@ const nextConfig = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: 'avatars3.githubusercontent.com'
+        hostname: '*' // Add image hostname to keep secure
       }
     ]
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linksforall",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "linksforall",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "@types/node": "18.11.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linksforall",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "Bruno Rodrigues",
   "repository": "itbruno/linksforall",
   "license": "MIT",

--- a/src/themes/alpha/components/Header.tsx
+++ b/src/themes/alpha/components/Header.tsx
@@ -17,6 +17,7 @@ function Header({ fullname, image, role, socialLinks }: UserProps) {
               alt={fullname}
               width={90}
               height={90}
+              priority
             />
           )}
 

--- a/src/themes/dracula/components/Header.tsx
+++ b/src/themes/dracula/components/Header.tsx
@@ -15,6 +15,7 @@ function Header({ fullname, image, role, socialLinks }: UserProps) {
               alt={fullname}
               width={90}
               height={90}
+              priority
             />
           )}
 


### PR DESCRIPTION
## Description
- Add wildcard as host to `remotePatterns` config. This enable to use any image hostname for pictures on project.
- Add `priority` param in header images to priorize image loading

## Related issue
- #9 